### PR TITLE
fix(Installation): Fix error when installing the package as dependency. #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
   },
   "homepage": "https://github.com/medihack/redux-pouchdb-plus#readme",
   "devDependencies": {
-    "babel-cli": "^6.4.5",
-    "babel-core": "^6.4.5",
-    "babel-preset-es2015": "^6.3.13",
     "babel-tape-runner": "^2.0.0",
     "memdown": "^1.1.1",
     "redux": "^3.0.5",
@@ -44,10 +41,13 @@
     "timeout-then": "^1.0.0"
   },
   "peerDependencies": {
-    "immutable": "^3.8.1",
     "pouchdb": "^6.2.0"
   },
   "dependencies": {
+    "babel-cli": "^6.4.5",
+    "babel-core": "^6.4.5",
+    "babel-preset-es2015": "^6.3.13",
+    "immutable": "^3.8.1",
     "lodash.clonedeep": "^4.1.0",
     "lodash.isequal": "^4.0.0",
     "transit-immutable-js": "^0.5.2",


### PR DESCRIPTION
When using `npm install` (or `yarn add`), `postinstall` scripts are triggered.
The problem is that, even if `babel` was added in `devDependencies`, it wasn't included when installing `redux-pouchdb-plus` in another application.
This fails on systems where `babel` isn't installed locally.

As a side-note, `Immutable` is directly imported in `index.js`, you need to add `immutable` in dependencies too ;).