### PR TITLE
Allow for pause and resuming of the saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,36 @@ persistentStore(counter, {
   }
 }
 ```
+### Pausing and resuming the save to the database 
+
+Saving the state to the database can be paused and resumed
+via the `PAUSE_SAVING` and `RESUME_SAVING` actions.
+
+```js
+import { PAUSE_SAVING, RESUME_SAVING, persistentStore, persistentReducer } 
+    from 'redux-pouchdb-plus';
+
+
+// create the store the usual way...
+
+store.dispatch( { type: 'INCREMENT' } );  // will be saved as usual 
+
+store.dispatch( { type: 'PAUSE_SAVING' } );   
+ 
+store.dispatch( { type: 'INCREMENT' } );  // won't be saved
+
+store.dispatch( { type: 'INCREMENT' } );  // won't be saved either
+
+store.dispatch( { type: 'RESUME_SAVING' } ); // saving is resumed
+
+store.dispatch( { type: 'INCREMENT' } );  // will be saved as usual 
+```
+
+If the store changed between a `PAUSE_SAVING` and the following 
+`RESUME_SAVING`, the `RESUME_SAVING` will immediately trigger a save.
+
+Note that `PAUSE_SAVING` prevents the local store from saving its 
+changes to the database, but won't prevent updates coming from the database.
 
 ## Notes
 

--- a/src/index.js
+++ b/src/index.js
@@ -181,27 +181,35 @@ export const persistentReducer = (reducer, reducerOptions={}) => {
   }
 
    const reduceAndMaybeSave = (state,action) => {
-        const nextState = reducer(state, action);
+    const nextState = reducer(state, action);
 
-        if (!initialState) {
-          initialState = nextState;
-        }
+    if (!initialState) {
+        initialState = nextState;
+    }
 
-        const isInitialized = initializedReducers[name];
-        if (isInitialized && !paused && !isEqual(nextState, currentState)) {
-          currentState = nextState;
-          saveReducer(name, toPouch(currentState)).then(() => {
-            onSave(currentState);
-          });
-        }
-        else currentState = nextState;
+    const isInitialized = initializedReducers[name];
 
-        return currentState;
+    if (isInitialized && !paused && !isEqual(nextState, currentState)) {
+        currentState = nextState;
+        saveReducer(name, toPouch(currentState)).then(() => {
+        onSave(currentState);
+        });
+    }
+    else if (!paused ) currentState = nextState;
+
+    return nextState;
    };
 
   // the proxy function that wraps the real reducer
   const proxyReducer = (state, action) => {
     switch (action.type) {
+      case PAUSE_SAVING:
+        paused = true;
+        return state;
+
+      case RESUME_SAVING:
+        paused = false;
+        return reduceAndMaybeSave(state,action);
       
       case INIT:
         store = action.store;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ const REINIT = '@@redux-pouchdb-plus/REINIT';
 const INIT = '@@redux-pouchdb-plus/INIT';
 const SET_REDUCER = '@@redux-pouchdb-plus/SET_REDUCER';
 
+export const PAUSE_SAVING  = '@@redux-pouchdb-plus/PAUSE_SAVING';
+export const RESUME_SAVING = '@@redux-pouchdb-plus/RESUME_SAVING';
+
 const allReducers = [];
 
 export function reinit(reducerName) {
@@ -46,6 +49,7 @@ export const persistentReducer = (reducer, reducerOptions={}) => {
   let saveReducer;
   let currentState;
   let name = reducerOptions.name ? reducerOptions.name : reducer.name;
+  let paused = false;
 
   initializedReducers[name] = false;
 
@@ -176,9 +180,29 @@ export const persistentReducer = (reducer, reducerOptions={}) => {
       return equalDeep(x, y);
   }
 
+   const reduceAndMaybeSave = (state,action) => {
+        const nextState = reducer(state, action);
+
+        if (!initialState) {
+          initialState = nextState;
+        }
+
+        const isInitialized = initializedReducers[name];
+        if (isInitialized && !paused && !isEqual(nextState, currentState)) {
+          currentState = nextState;
+          saveReducer(name, toPouch(currentState)).then(() => {
+            onSave(currentState);
+          });
+        }
+        else currentState = nextState;
+
+        return currentState;
+   };
+
   // the proxy function that wraps the real reducer
   const proxyReducer = (state, action) => {
     switch (action.type) {
+      
       case INIT:
         store = action.store;
         storeOptions = action.storeOptions;
@@ -205,24 +229,8 @@ export const persistentReducer = (reducer, reducerOptions={}) => {
         }
         // falls through
 
-      default: {
-        const nextState = reducer(state, action);
-
-        if (!initialState) {
-          initialState = nextState;
-        }
-
-        const isInitialized = initializedReducers[name];
-        if (isInitialized && !isEqual(nextState, currentState)) {
-          currentState = nextState;
-          saveReducer(name, toPouch(currentState)).then(() => {
-            onSave(currentState);
-          });
-        }
-        else currentState = nextState;
-
-        return currentState;
-      }
+      default: 
+        return reduceAndMaybeSave(state,action);
     }
   };
 


### PR DESCRIPTION
Useful, in my case, because I only want to send the local state to the database when we hit milestone actions. Something like transactions, if you will.

```js
        store.dispatch( { type: PAUSE_SAVING } );

        store.dispatch( this );
        store.dispatch( that );

        // all went well? Okay, push to the db
        store.dispatch( { type: RESUME_SAVING } )
```